### PR TITLE
466 addressing issues with slice thickness

### DIFF
--- a/hazenlib/ACRObject.py
+++ b/hazenlib/ACRObject.py
@@ -577,13 +577,9 @@ class ACRObject:
         mid_mask = lower_mask ^ upper_mask
         masked_data = np.ma.masked_array(data.copy(), mask=mid_mask, fill_value=0)
         # Apply thresholds
-        if len(masked_data[~mid_mask]):
-            masked_data[lower_mask] = dtmin
-            masked_data[upper_mask] = dtmax
-            masked_data[~mid_mask] = ((masked_data[~mid_mask] - (center - 0.5)) / adjusted_width + 0.5) * (dtmax - dtmin) + dtmin
-        else:
-            masked_data[lower_mask] = dtmin
-            masked_data[upper_mask] = dtmax
+        masked_data[~mid_mask] = ((masked_data[~mid_mask] - (center - 0.5)) / adjusted_width + 0.5) * (dtmax - dtmin) + dtmin
+        masked_data[lower_mask] = dtmin
+        masked_data[upper_mask] = dtmax
         return masked_data
 
     @staticmethod
@@ -630,13 +626,9 @@ class ACRObject:
         mid_mask = lower_mask ^ upper_mask
         masked_data = np.ma.masked_array(data.copy(), mask=mid_mask, fill_value=0)
         # Apply thresholds
-        if len(masked_data[~mid_mask]):
-            masked_data[lower_mask] = dtmin
-            masked_data[upper_mask] = dtmax
-            masked_data[~mid_mask] = ((masked_data[~mid_mask] - center) / width + 0.5) * (dtmax - dtmin) + dtmin
-        else:
-            masked_data[lower_mask] = dtmin
-            masked_data[upper_mask] = dtmax
+        masked_data[~mid_mask] = ((masked_data[~mid_mask] - center) / width + 0.5) * (dtmax - dtmin) + dtmin
+        masked_data[lower_mask] = dtmin
+        masked_data[upper_mask] = dtmax
         return masked_data
 
     @staticmethod
@@ -701,13 +693,9 @@ class ACRObject:
         mid_mask = lower_mask ^ upper_mask
         masked_data = np.ma.masked_array(data.copy(), mask=mid_mask, fill_value=0)
         # Apply thresholds
-        if len(masked_data[~mid_mask]):
-            masked_data[lower_mask] = dtmin
-            masked_data[upper_mask] = dtmax
-            masked_data[~mid_mask] = np.clip(masked_data[~mid_mask], lower_grey, upper_grey)
-        else:
-            masked_data[lower_mask] = dtmin
-            masked_data[upper_mask] = dtmax
+        masked_data[~mid_mask] = np.clip(masked_data[~mid_mask], lower_grey, upper_grey)
+        masked_data[lower_mask] = dtmin
+        masked_data[upper_mask] = dtmax
         return masked_data
 
     @staticmethod

--- a/hazenlib/tasks/acr_slice_thickness.py
+++ b/hazenlib/tasks/acr_slice_thickness.py
@@ -1,5 +1,6 @@
 """
 ACR Slice Thickness
+___________________
 
 Calculates the slice thickness for slice 1 of the ACR phantom.
 
@@ -11,6 +12,77 @@ Created by Yassine Azma
 yassine.azma@rmh.nhs.uk
 
 31/01/2022
+
+
+Reference
+_________
+
+`ACR Large Phantom Guidance PDF <https://accreditationsupport.acr.org/helpdesk/attachments/11093487417>`_
+
+Intro
+_____
+
+The slice thickness accuracy test assesses the accuracy with which a slice of specified thickness is achieved.
+The prescribed slice thickness is compared with the measured slice thickness.
+
+The ramps appear in a structure called the slice thickness insert. Figure 10 shows an image of slice 1 with
+the slice thickness insert and signal ramps identified. The two ramps are crossed: one has a negative slope
+and the other a positive slope with respect to the plane of slice 1. They are produced by cutting 1 mm wide
+slots in a block of plastic. The slots are open to the interior of the phantom and are filled with the same
+solution that fills the bulk of the phantom.
+
+The signal ramps have a slope of 10 to 1 with respect to the plane of slice 1, which is an angle of about 5.71°.
+Therefore, the signal ramps will appear in the image of slice 1 with a length that is 10 times the thickness of
+the slice. If the phantom is misaligned from right-left, one ramp will appear longer than the other. The
+crossed ramps allow for correction of the error introduced by right-left misalignment, and the slice thickness
+formula takes that into account.
+
+ACR Guidelines
+______________
+
+ACR Algorithm
++++++++++++++
+
+    #. Display slice 1, and magnify the image by a factor of 2 to 4, keeping the slice thickness insert fully
+        visible on the screen.
+    #. Adjust the display level so that the signal ramps are well visualized.
+        *. The ramp signal is much lower than that of surrounding water, so usually it will be necessary
+            to lower the display level substantially and narrow the window.
+    #. Place a rectangular ROI at the middle of each ramp as shown below in Figure 11.
+        *. Note the mean signal values for each of these two ROIs and then average those values.
+        *. The result is a number approximating the mean signal in the middle of the ramps.
+        *. An elliptical ROI may be used if a rectangular one is unavailable.
+    #. Lower the display level to half of the average ramp signal calculated in step 3.
+        *. Leave the display window set to its minimum.
+    #. Use the on-screen distance measurement tool to measure the lengths of the top and bottom ramps.
+        This is illustrated below in Figure 12. Record these lengths and compare to the action limits.
+
+ACR Scoring Rubric
+++++++++++++++++++
+
+
+Notes
+_____
+
+..note::
+
+    A failure of this test means that the scanner is producing slices of substantially different thickness from the
+    prescribed thickness. This problem will generally not occur in isolation since the scanner deficiencies that
+    can cause it may also cause other image problems. Therefore, the implications of a failure are not just that
+    the slices are too thick or thin, but can also result in poor image contrast and low SNR.
+
+..warning::
+
+    When making these measurements, **be careful to fully cover the widths of the ramp with the
+    ROIs** in the top-bottom direction, but not to allow the ROIs to stray outside the ramps into adjacent
+    high- or low-signal regions. If there is a large difference,(that is, more than 20%), between the signal
+    values obtained for the ROIs, it is often due to one or both of the ROIs including regions outside the
+    ramps.
+
+Documented by Luis M. Santos, M.D.
+luis.santos2@nih.gov
+
+
 """
 
 import os
@@ -24,6 +96,7 @@ import skimage.measure
 
 from hazenlib.HazenTask import HazenTask
 from hazenlib.ACRObject import ACRObject
+from hazenlib.logger import logger
 from hazenlib.utils import get_image_orientation
 
 
@@ -67,7 +140,7 @@ class ACRSliceThickness(HazenTask):
             result = self.get_slice_thickness(slice_thickness_dcm)
             results["measurement"] = {"slice width mm": round(result, 2)}
         except Exception as e:
-            print(
+            logger.error(
                 f"Could not calculate the slice thickness for {self.img_desc(slice_thickness_dcm)} because of : {e}"
             )
             traceback.print_exc(file=sys.stdout)

--- a/hazenlib/tasks/acr_spatial_resolution.py
+++ b/hazenlib/tasks/acr_spatial_resolution.py
@@ -68,16 +68,10 @@ import sys
 import traceback
 import numpy as np
 
-import cv2
-import scipy
-import skimage.morphology
-import skimage.measure
-from matplotlib.image import NonUniformImage
-
 from hazenlib.HazenTask import HazenTask
 from hazenlib.ACRObject import ACRObject
 from hazenlib.logger import logger
-from hazenlib.utils import create_rectangular_roi_at, debug_image_sample, wait_on_parallel_results
+from hazenlib.utils import wait_on_parallel_results
 
 
 class ACRSpatialResolution(HazenTask):
@@ -87,10 +81,10 @@ class ACRSpatialResolution(HazenTask):
     """
 
     ROI_OFFSET = 23         #: 23mm separation between ROIs
-    BASE_X_OFFSET = -14  #: -16mm from centroid for 1.1mm resolution array
-    BASE_Y_OFFSET = 40   #: 35mm from centroid for 1.1mm resolution array
+    BASE_X_OFFSET = -14     #: -14mm from centroid for 1.1mm resolution array
+    BASE_Y_OFFSET = 40      #: 40mm from centroid for 1.1mm resolution array
     DEFAULT_GROUP_SIZE = 2  #: If a dataset is a 1mm resolution, the crop roi is sized such that we can check a row's
-                            # value by looking at pairs of rows in data
+                            #: value by looking at pairs of rows in data
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -125,7 +119,7 @@ class ACRSpatialResolution(HazenTask):
                 "rows": hole_arrays
             }
         except Exception as e:
-            print(
+            logger.error(
                 f"Could not calculate the spatial resolution for {self.img_desc(dcm)} because of : {e}"
             )
             traceback.print_exc(file=sys.stdout)

--- a/hazenlib/tasks/acr_spatial_resolution.py
+++ b/hazenlib/tasks/acr_spatial_resolution.py
@@ -332,9 +332,6 @@ class ACRSpatialResolution(HazenTask):
                 return i + 1
         return -1
 
-    def get_rois(self, rescaled, width, height, center):
-        ...
-
     def get_spatially_resolved_rows(self, dcm):
         """Generates a series of ROIs centered around the hole arrays present in the ACR phantom.
         Preprocesses these rois and then attempts to detect hole array.

--- a/hazenlib/tasks/legacy_slice_thickness.py
+++ b/hazenlib/tasks/legacy_slice_thickness.py
@@ -12,77 +12,6 @@ Created by Yassine Azma
 yassine.azma@rmh.nhs.uk
 
 31/01/2022
-
-
-Reference
-_________
-
-`ACR Large Phantom Guidance PDF <https://accreditationsupport.acr.org/helpdesk/attachments/11093487417>`_
-
-Intro
-_____
-
-The slice thickness accuracy test assesses the accuracy with which a slice of specified thickness is achieved.
-The prescribed slice thickness is compared with the measured slice thickness.
-
-The ramps appear in a structure called the slice thickness insert. Figure 10 shows an image of slice 1 with
-the slice thickness insert and signal ramps identified. The two ramps are crossed: one has a negative slope
-and the other a positive slope with respect to the plane of slice 1. They are produced by cutting 1 mm wide
-slots in a block of plastic. The slots are open to the interior of the phantom and are filled with the same
-solution that fills the bulk of the phantom.
-
-The signal ramps have a slope of 10 to 1 with respect to the plane of slice 1, which is an angle of about 5.71°.
-Therefore, the signal ramps will appear in the image of slice 1 with a length that is 10 times the thickness of
-the slice. If the phantom is misaligned from right-left, one ramp will appear longer than the other. The
-crossed ramps allow for correction of the error introduced by right-left misalignment, and the slice thickness
-formula takes that into account.
-
-ACR Guidelines
-______________
-
-ACR Algorithm
-+++++++++++++
-
-    #. Display slice 1, and magnify the image by a factor of 2 to 4, keeping the slice thickness insert fully
-        visible on the screen.
-    #. Adjust the display level so that the signal ramps are well visualized.
-        *. The ramp signal is much lower than that of surrounding water, so usually it will be necessary
-            to lower the display level substantially and narrow the window.
-    #. Place a rectangular ROI at the middle of each ramp as shown below in Figure 11.
-        *. Note the mean signal values for each of these two ROIs and then average those values.
-        *. The result is a number approximating the mean signal in the middle of the ramps.
-        *. An elliptical ROI may be used if a rectangular one is unavailable.
-    #. Lower the display level to half of the average ramp signal calculated in step 3.
-        *. Leave the display window set to its minimum.
-    #. Use the on-screen distance measurement tool to measure the lengths of the top and bottom ramps.
-        This is illustrated below in Figure 12. Record these lengths and compare to the action limits.
-
-ACR Scoring Rubric
-++++++++++++++++++
-
-
-Notes
-_____
-
-..note::
-
-    A failure of this test means that the scanner is producing slices of substantially different thickness from the
-    prescribed thickness. This problem will generally not occur in isolation since the scanner deficiencies that
-    can cause it may also cause other image problems. Therefore, the implications of a failure are not just that
-    the slices are too thick or thin, but can also result in poor image contrast and low SNR.
-
-..warning::
-
-    When making these measurements, **be careful to fully cover the widths of the ramp with the
-    ROIs** in the top-bottom direction, but not to allow the ROIs to stray outside the ramps into adjacent
-    high- or low-signal regions. If there is a large difference,(that is, more than 20%), between the signal
-    values obtained for the ROIs, it is often due to one or both of the ROIs including regions outside the
-    ramps.
-
-Documented by Luis M. Santos, M.D.
-luis.santos2@nih.gov
-
-
 """
 
 import os
@@ -98,7 +27,6 @@ from hazenlib.HazenTask import HazenTask
 from hazenlib.ACRObject import ACRObject
 from hazenlib.logger import logger
 from hazenlib.utils import get_image_orientation
-
 
 
 class LegacySliceThickness(HazenTask):

--- a/hazenlib/tasks/legacy_slice_thickness.py
+++ b/hazenlib/tasks/legacy_slice_thickness.py
@@ -1,0 +1,417 @@
+"""
+ACR Slice Thickness
+___________________
+
+Calculates the slice thickness for slice 1 of the ACR phantom.
+
+The ramps located in the middle of the phantom are located and line profiles are drawn through them. The full-width
+half-maximum (FWHM) of each ramp is determined to be their length. Using the formula described in the ACR guidance, the
+slice thickness is then calculated.
+
+Created by Yassine Azma
+yassine.azma@rmh.nhs.uk
+
+31/01/2022
+
+
+Reference
+_________
+
+`ACR Large Phantom Guidance PDF <https://accreditationsupport.acr.org/helpdesk/attachments/11093487417>`_
+
+Intro
+_____
+
+The slice thickness accuracy test assesses the accuracy with which a slice of specified thickness is achieved.
+The prescribed slice thickness is compared with the measured slice thickness.
+
+The ramps appear in a structure called the slice thickness insert. Figure 10 shows an image of slice 1 with
+the slice thickness insert and signal ramps identified. The two ramps are crossed: one has a negative slope
+and the other a positive slope with respect to the plane of slice 1. They are produced by cutting 1 mm wide
+slots in a block of plastic. The slots are open to the interior of the phantom and are filled with the same
+solution that fills the bulk of the phantom.
+
+The signal ramps have a slope of 10 to 1 with respect to the plane of slice 1, which is an angle of about 5.71°.
+Therefore, the signal ramps will appear in the image of slice 1 with a length that is 10 times the thickness of
+the slice. If the phantom is misaligned from right-left, one ramp will appear longer than the other. The
+crossed ramps allow for correction of the error introduced by right-left misalignment, and the slice thickness
+formula takes that into account.
+
+ACR Guidelines
+______________
+
+ACR Algorithm
++++++++++++++
+
+    #. Display slice 1, and magnify the image by a factor of 2 to 4, keeping the slice thickness insert fully
+        visible on the screen.
+    #. Adjust the display level so that the signal ramps are well visualized.
+        *. The ramp signal is much lower than that of surrounding water, so usually it will be necessary
+            to lower the display level substantially and narrow the window.
+    #. Place a rectangular ROI at the middle of each ramp as shown below in Figure 11.
+        *. Note the mean signal values for each of these two ROIs and then average those values.
+        *. The result is a number approximating the mean signal in the middle of the ramps.
+        *. An elliptical ROI may be used if a rectangular one is unavailable.
+    #. Lower the display level to half of the average ramp signal calculated in step 3.
+        *. Leave the display window set to its minimum.
+    #. Use the on-screen distance measurement tool to measure the lengths of the top and bottom ramps.
+        This is illustrated below in Figure 12. Record these lengths and compare to the action limits.
+
+ACR Scoring Rubric
+++++++++++++++++++
+
+
+Notes
+_____
+
+..note::
+
+    A failure of this test means that the scanner is producing slices of substantially different thickness from the
+    prescribed thickness. This problem will generally not occur in isolation since the scanner deficiencies that
+    can cause it may also cause other image problems. Therefore, the implications of a failure are not just that
+    the slices are too thick or thin, but can also result in poor image contrast and low SNR.
+
+..warning::
+
+    When making these measurements, **be careful to fully cover the widths of the ramp with the
+    ROIs** in the top-bottom direction, but not to allow the ROIs to stray outside the ramps into adjacent
+    high- or low-signal regions. If there is a large difference,(that is, more than 20%), between the signal
+    values obtained for the ROIs, it is often due to one or both of the ROIs including regions outside the
+    ramps.
+
+Documented by Luis M. Santos, M.D.
+luis.santos2@nih.gov
+
+
+"""
+
+import os
+import sys
+import traceback
+import numpy as np
+
+import scipy
+import skimage.morphology
+import skimage.measure
+
+from hazenlib.HazenTask import HazenTask
+from hazenlib.ACRObject import ACRObject
+from hazenlib.logger import logger
+from hazenlib.utils import get_image_orientation
+
+
+
+class LegacySliceThickness(HazenTask):
+    """Slice width measurement class for DICOM images of the ACR phantom."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # Initialise ACR object
+        self.ACR_obj = ACRObject(self.dcm_list)
+
+    def run(self) -> dict:
+        """Main function for performing slice width measurement
+        using slice 1 from the ACR phantom image set.
+
+        Returns:
+            dict: results are returned in a standardised dictionary structure specifying the task name, input DICOM Series Description + SeriesNumber + InstanceNumber, task measurement key-value pairs, optionally path to the generated images for visualisation.
+        """
+        # Identify relevant slice
+        slice_thickness_dcm = self.ACR_obj.slice_stack[0]
+        # TODO image may be 90 degrees cw or acw, could use code to identify which or could be added as extra arg
+
+        ori = get_image_orientation(slice_thickness_dcm)
+        if ori == 'Sagittal':
+            # Get the pixel array from the DICOM file
+            img = slice_thickness_dcm.pixel_array
+
+            # Rotate the image 90 degrees clockwise
+
+            rotated_img = np.rot90(img, k=-1)  # k=-1 for 90 degrees clockwise
+
+            # Update the pixel array in the DICOM object
+            slice_thickness_dcm.PixelData = rotated_img.tobytes()
+
+        # Initialise results dictionary
+        results = self.init_result_dict()
+        results["file"] = self.img_desc(slice_thickness_dcm)
+
+        try:
+            result = self.get_slice_thickness(slice_thickness_dcm)
+            results["measurement"] = {"slice width mm": round(result, 2)}
+        except Exception as e:
+            logger.error(
+                f"Could not calculate the slice thickness for {self.img_desc(slice_thickness_dcm)} because of : {e}"
+            )
+            traceback.print_exc(file=sys.stdout)
+
+        # only return reports if requested
+        if self.report:
+            results["report_image"] = self.report_files
+
+        return results
+
+    def find_ramps(self, img, centre):
+        """Find ramps in the pixel array and return the co-ordinates of their location.
+
+        Args:
+            img (np.ndarray): dcm.pixel_array
+            centre (list): x,y coordinates of the phantom centre
+
+        Returns:
+            tuple: x and y coordinates of ramp.
+        """
+        # X
+        investigate_region = int(np.ceil(5.5 / self.ACR_obj.dy).item())
+
+        if np.mod(investigate_region, 2) == 0:
+            investigate_region = investigate_region + 1
+
+        # Line profiles around the central row
+        invest_x = [
+            skimage.measure.profile_line(
+                img, (centre[1] + k, 1), (centre[1] + k, img.shape[1]), mode="constant"
+            )
+            for k in range(investigate_region)
+        ]
+
+        invest_x = np.array(invest_x).T
+        mean_x_profile = np.mean(invest_x, 1)
+        abs_diff_x_profile = np.absolute(np.diff(mean_x_profile))
+
+        # find the points corresponding to the transition between:
+        # [0] - background and the hyperintense phantom
+        # [1] - hyperintense phantom and hypointense region with ramps
+        # [2] - hypointense region with ramps and hyperintense phantom
+        # [3] - hyperintense phantom and background
+
+        x_peaks, _ = self.ACR_obj.find_n_highest_peaks(abs_diff_x_profile, 4)
+        x_locs = np.sort(x_peaks) - 1
+
+        width_pts = [x_locs[1], x_locs[2]]
+        width = np.max(width_pts) - np.min(width_pts)
+
+        # take rough estimate of x points for later line profiles
+        x = np.round([np.min(width_pts) + 0.2 * width, np.max(width_pts) - 0.2 * width])
+
+        # Y
+        c = skimage.measure.profile_line(
+            img,
+            (centre[1] - 2 * investigate_region, centre[0]),
+            (centre[1] + 2 * investigate_region, centre[0]),
+            mode="constant",
+        ).flatten()
+
+        abs_diff_y_profile = np.absolute(np.diff(c))
+
+        y_peaks, _ = self.ACR_obj.find_n_highest_peaks(abs_diff_y_profile, 2)
+        y_locs = centre[1] - 2 * investigate_region + 1 + y_peaks
+        height = np.max(y_locs) - np.min(y_locs)
+
+        y = np.round([np.max(y_locs) - 0.25 * height, np.min(y_locs) + 0.25 * height])
+
+        return x, y
+
+    def FWHM(self, data):
+        """Calculate full width at half maximum of the line profile.
+
+        Args:
+            data (np.ndarray): slice profile curve.
+
+        Returns:
+            tuple: co-ordinates of the half-maximum points on the line profile.
+        """
+        baseline = np.min(data)
+        data -= baseline
+        # TODO create separate variable so that data value isn't being overwritten
+        half_max = np.max(data) * 0.5
+
+        # Naive attempt
+        half_max_crossing_indices = np.argwhere(
+            np.diff(np.sign(data - half_max))
+        ).flatten()
+
+        # Interpolation
+        def simple_interp(x_start, ydata):
+            """Simple interpolation - obtaining more accurate x co-ordinates.
+
+            Args:
+                x_start (int or float): x coordinate of the half maximum.
+                ydata (np.ndarray): y coordinates.
+
+            Returns:
+                float: true x coordinate of the half maximum.
+            """
+            x_points = np.arange(x_start - 5, x_start + 6)
+            # Check if expected x_pts (indices) will be out of range ( >= len(ydata))
+            inrange = np.where(x_points == len(ydata))[0]
+            if np.size(inrange) > 0:
+                # locate index of where ydata ends within x_pts
+                # crop x_pts until len(ydata)
+                x_pts = x_points[: inrange.flatten()[0]]
+            else:
+                x_pts = x_points
+
+            y_pts = ydata[x_pts]
+
+            grad = (y_pts[-1] - y_pts[0]) / (x_pts[-1] - x_pts[0])
+
+            x_true = x_start + (half_max - ydata[x_start]) / grad
+
+            return x_true
+
+        FWHM_pts = simple_interp(half_max_crossing_indices[0], data), simple_interp(
+            half_max_crossing_indices[-1], data
+        )
+        return FWHM_pts
+
+    def get_slice_thickness(self, dcm):
+        """Measure slice thickness. \n
+        Identify the ramps, measure the line profile, measure the FWHM, and use this to calculate the slice thickness.
+
+        Args:
+            dcm (pydicom.Dataset): DICOM image object.
+
+        Returns:
+            float: measured slice thickness.
+        """
+        #img = dcm.pixel_array
+        img, rescaled, presentation = self.ACR_obj.get_presentation_pixels(dcm)
+        cxy, _ = self.ACR_obj.find_phantom_center(rescaled, self.ACR_obj.dx, self.ACR_obj.dy)
+        blurred = self.ACR_obj.filter_with_gaussian(rescaled, 1)
+        x_pts, y_pts = self.find_ramps(blurred, cxy)
+
+        interp_factor = 1 / 5
+        interp_factor_dx = interp_factor * self.ACR_obj.dx
+        sample = np.arange(1, x_pts[1] - x_pts[0] + 2)
+        new_sample = np.arange(1, x_pts[1] - x_pts[0] + interp_factor, interp_factor)
+        offsets = np.arange(-3, 4)
+        ramp_length = np.zeros((2, 7))
+
+        line_store = []
+        fwhm_store = []
+        for i, offset in enumerate(offsets):
+            lines = [
+                skimage.measure.profile_line(
+                    blurred,
+                    (offset + y_pts[0], x_pts[0]),
+                    (offset + y_pts[0], x_pts[1]),
+                    linewidth=2,
+                    mode="constant",
+                ).flatten(),
+                skimage.measure.profile_line(
+                    blurred,
+                    (offset + y_pts[1], x_pts[0]),
+                    (offset + y_pts[1], x_pts[1]),
+                    linewidth=2,
+                    mode="constant",
+                ).flatten(),
+            ]
+
+            interp_lines = [
+                scipy.interpolate.interp1d(sample, line)(new_sample) for line in lines
+            ]
+            fwhm = [self.FWHM(interp_line) for interp_line in interp_lines]
+            ramp_length[0, i] = interp_factor_dx * np.diff(fwhm[0])
+            ramp_length[1, i] = interp_factor_dx * np.diff(fwhm[1])
+
+            line_store.append(interp_lines)
+            fwhm_store.append(fwhm)
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            dz = 0.2 * (np.prod(ramp_length, axis=0)) / np.sum(ramp_length, axis=0)
+
+        dz = dz[~np.isnan(dz)]
+        # TODO check this - if it's taking the value closest to the DICOM slice thickness this is potentially not accurate?
+        z_ind = np.argmin(np.abs(dcm.SliceThickness - dz))
+
+        slice_thickness = dz[z_ind]
+
+        if self.report:
+            import matplotlib.pyplot as plt
+
+            fig, axes = plt.subplots(4, 1)
+            fig.set_size_inches(8, 24)
+            fig.tight_layout(pad=4)
+
+            x_ramp = new_sample * self.ACR_obj.dx
+            x_extent = np.max(x_ramp)
+            y_ramp = line_store[z_ind][1]
+            y_extent = np.max(y_ramp)
+            max_loc = np.argmax(y_ramp) * interp_factor_dx
+
+            axes[0].imshow(img)
+            axes[0].scatter(cxy[0], cxy[1], c="red")
+            axes[0].axis("off")
+            axes[0].set_title("Centroid Location")
+
+            axes[1].imshow(img)
+            axes[1].plot(
+                [x_pts[0], x_pts[1]], offsets[z_ind] + [y_pts[0], y_pts[0]], "b-"
+            )
+            axes[1].plot(
+                [x_pts[0], x_pts[1]], offsets[z_ind] + [y_pts[1], y_pts[1]], "r-"
+            )
+            axes[1].axis("off")
+            axes[1].set_title("Line Profiles")
+
+            xmin = fwhm_store[z_ind][1][0] * interp_factor_dx / x_extent
+            xmax = fwhm_store[z_ind][1][1] * interp_factor_dx / x_extent
+
+            axes[2].plot(
+                x_ramp,
+                y_ramp,
+                "r",
+                label=f"FWHM={np.round(ramp_length[1][z_ind], 2)}mm",
+            )
+            axes[2].axhline(
+                0.5 * y_extent, linestyle="dashdot", color="k", xmin=xmin, xmax=xmax
+            )
+            axes[2].axvline(
+                max_loc, linestyle="dashdot", color="k", ymin=0, ymax=10 / 11
+            )
+
+            axes[2].set_xlabel("Relative Position (mm)")
+            axes[2].set_xlim([0, x_extent])
+            axes[2].set_ylim([0, y_extent * 1.1])
+            axes[2].set_title("Upper Ramp")
+            axes[2].grid()
+            axes[2].legend(loc="best")
+
+            xmin = fwhm_store[z_ind][0][0] * interp_factor_dx / x_extent
+            xmax = fwhm_store[z_ind][0][1] * interp_factor_dx / x_extent
+            x_ramp = new_sample * self.ACR_obj.dx
+            x_extent = np.max(x_ramp)
+            y_ramp = line_store[z_ind][0]
+            y_extent = np.max(y_ramp)
+            max_loc = np.argmax(y_ramp) * interp_factor_dx
+
+            axes[3].plot(
+                x_ramp,
+                y_ramp,
+                "b",
+                label=f"FWHM={np.round(ramp_length[0][z_ind], 2)}mm",
+            )
+            axes[3].axhline(
+                0.5 * y_extent, xmin=xmin, xmax=xmax, linestyle="dashdot", color="k"
+            )
+            axes[3].axvline(
+                max_loc, ymin=0, ymax=10 / 11, linestyle="dashdot", color="k"
+            )
+
+            axes[3].set_xlabel("Relative Position (mm)")
+            axes[3].set_xlim([0, x_extent])
+            axes[3].set_ylim([0, y_extent * 1.1])
+            axes[3].set_title("Lower Ramp")
+            axes[3].grid()
+            axes[3].legend(loc="best")
+
+            img_path = os.path.realpath(
+                os.path.join(
+                    self.report_path, f"{self.img_desc(dcm)}_slice_thickness.png"
+                )
+            )
+            fig.savefig(img_path)
+            self.report_files.append(img_path)
+
+        return slice_thickness

--- a/tests/test_acr_slice_thickness.py
+++ b/tests/test_acr_slice_thickness.py
@@ -11,9 +11,8 @@ from tests import TEST_DATA_DIR
 
 class TestACRSliceThicknessSiemens(unittest.TestCase):
     ACR_DATA = pathlib.Path(TEST_DATA_DIR / "acr" / "Siemens")
-    x_pts = [71, 181]
-    y_pts = [132, 126]
-    dz = 4.91
+    centers = [(46.0, 2.0), (46.5, 2.0)]
+    dz = 5.8
 
     def setUp(self):
         input_files = get_dicom_files(self.ACR_DATA)
@@ -24,21 +23,11 @@ class TestACRSliceThicknessSiemens(unittest.TestCase):
         self.centre, _ = self.acr_slice_thickness_task.ACR_obj.find_phantom_center(
             self.dcm.pixel_array, self.dcm.PixelSpacing[0], self.dcm.PixelSpacing[1]
         )
-
-    def test_ramp_find(self):
-        x_pts, y_pts = self.acr_slice_thickness_task.find_ramps(
-            self.dcm.pixel_array, self.centre
-        )
-        print(f'Slice Thickness ramp x_pts => {x_pts}')
-        print(f'Slice Thickness ramp y_pts => {y_pts}')
-
-        assert (x_pts == self.x_pts).all() == True
-
-        assert (y_pts == self.y_pts).all() == True
+        self.results = self.acr_slice_thickness_task.get_slice_thickness(self.dcm)
 
     def test_slice_thickness(self):
         slice_thickness_val = round(
-            self.acr_slice_thickness_task.get_slice_thickness(self.dcm), 2
+            self.results['thickness'], 2
         )
 
         print("\ntest_slice_thickness.py::TestSliceThickness::test_slice_thickness")
@@ -47,9 +36,23 @@ class TestACRSliceThicknessSiemens(unittest.TestCase):
 
         assert slice_thickness_val == self.dz
 
+    def test_ramp_slot_relative_centers(self):
+        centers = [self.results['ramps']['top']['center'], self.results['ramps']['bottom']['center']]
 
-class TestACRSliceThicknessGE(TestACRSliceThicknessSiemens):
-    ACR_DATA = pathlib.Path(TEST_DATA_DIR / "acr" / "GE")
-    x_pts = [146, 356]
-    y_pts = [262, 250]
-    dz = 5.02
+        print("\ntest_slice_thickness.py::TestSliceThickness::test_ramp_slot_relative_centers")
+        print("new_release_value:", centers)
+        print("fixed_value:", self.centers)
+
+        assert centers == self.centers
+
+
+class TestACRSliceThicknessPhilipsAchieva(TestACRSliceThicknessSiemens):
+    ACR_DATA = pathlib.Path(TEST_DATA_DIR / "acr" / "PhilipsAchieva")
+    centers = [(47.5, 2.0), (40.0, 2.0)]
+    dz = 4.9
+
+
+class TestACRSliceThicknessSiemensSolaFit(TestACRSliceThicknessSiemens):
+    ACR_DATA = pathlib.Path(TEST_DATA_DIR / "acr" / "SiemensSolaFit")
+    centers = [(42.0, 2.0), (47.0, 2.0)]
+    dz = 4.4

--- a/tests/test_legacy_slice_thickness.py
+++ b/tests/test_legacy_slice_thickness.py
@@ -13,7 +13,7 @@ class TestACRSliceThicknessSiemens(unittest.TestCase):
     ACR_DATA = pathlib.Path(TEST_DATA_DIR / "acr" / "Siemens")
     x_pts = [71, 181]
     y_pts = [132, 126]
-    dz = 4.91
+    dz = 3.72
 
     def setUp(self):
         input_files = get_dicom_files(self.ACR_DATA)
@@ -52,4 +52,4 @@ class TestACRSliceThicknessGE(TestACRSliceThicknessSiemens):
     ACR_DATA = pathlib.Path(TEST_DATA_DIR / "acr" / "GE")
     x_pts = [146, 356]
     y_pts = [262, 250]
-    dz = 5.02
+    dz = 5.01

--- a/tests/test_legacy_slice_thickness.py
+++ b/tests/test_legacy_slice_thickness.py
@@ -4,7 +4,7 @@ import pathlib
 import pydicom
 
 from hazenlib.utils import get_dicom_files
-from hazenlib.tasks.acr_slice_thickness import ACRSliceThickness
+from hazenlib.tasks.legacy_slice_thickness import LegacySliceThickness
 from hazenlib.ACRObject import ACRObject
 from tests import TEST_DATA_DIR
 
@@ -18,7 +18,7 @@ class TestACRSliceThicknessSiemens(unittest.TestCase):
     def setUp(self):
         input_files = get_dicom_files(self.ACR_DATA)
 
-        self.acr_slice_thickness_task = ACRSliceThickness(input_data=input_files)
+        self.acr_slice_thickness_task = LegacySliceThickness(input_data=input_files)
 
         self.dcm = self.acr_slice_thickness_task.ACR_obj.slice_stack[0]
         self.centre, _ = self.acr_slice_thickness_task.ACR_obj.find_phantom_center(

--- a/tests/test_legacy_slice_thickness.py
+++ b/tests/test_legacy_slice_thickness.py
@@ -1,0 +1,55 @@
+import os
+import unittest
+import pathlib
+import pydicom
+
+from hazenlib.utils import get_dicom_files
+from hazenlib.tasks.acr_slice_thickness import ACRSliceThickness
+from hazenlib.ACRObject import ACRObject
+from tests import TEST_DATA_DIR
+
+
+class TestACRSliceThicknessSiemens(unittest.TestCase):
+    ACR_DATA = pathlib.Path(TEST_DATA_DIR / "acr" / "Siemens")
+    x_pts = [71, 181]
+    y_pts = [132, 126]
+    dz = 4.91
+
+    def setUp(self):
+        input_files = get_dicom_files(self.ACR_DATA)
+
+        self.acr_slice_thickness_task = ACRSliceThickness(input_data=input_files)
+
+        self.dcm = self.acr_slice_thickness_task.ACR_obj.slice_stack[0]
+        self.centre, _ = self.acr_slice_thickness_task.ACR_obj.find_phantom_center(
+            self.dcm.pixel_array, self.dcm.PixelSpacing[0], self.dcm.PixelSpacing[1]
+        )
+
+    def test_ramp_find(self):
+        x_pts, y_pts = self.acr_slice_thickness_task.find_ramps(
+            self.dcm.pixel_array, self.centre
+        )
+        print(f'Slice Thickness ramp x_pts => {x_pts}')
+        print(f'Slice Thickness ramp y_pts => {y_pts}')
+
+        assert (x_pts == self.x_pts).all() == True
+
+        assert (y_pts == self.y_pts).all() == True
+
+    def test_slice_thickness(self):
+        slice_thickness_val = round(
+            self.acr_slice_thickness_task.get_slice_thickness(self.dcm), 2
+        )
+
+        print("\ntest_slice_thickness.py::TestSliceThickness::test_slice_thickness")
+        print("new_release_value:", slice_thickness_val)
+        print("fixed_value:", self.dz)
+
+        assert slice_thickness_val == self.dz
+
+
+class TestACRSliceThicknessGE(TestACRSliceThicknessSiemens):
+    ACR_DATA = pathlib.Path(TEST_DATA_DIR / "acr" / "GE")
+    x_pts = [146, 356]
+    y_pts = [262, 250]
+    dz = 5.02


### PR DESCRIPTION
Addresses the instability with slot sampling.
During this process, I ended up rewriting the task.
At the end of the day, both the previous task version and the new version roughly attempt similar ideas. Th main difference is that I do not compute the fwhm. Instead, I use the numpy mean function during line profiling to collapse the sample. Then, I use the returned peaks for a simple calculation of width similar to how a human is expected to do for the ACR.